### PR TITLE
Use find_library and find_package to link libraries in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 project(sandbox)
 cmake_minimum_required(VERSION 3.0)
 
+find_library(STDCPPFS_LIBRARY stdc++fs)
+find_package(fmt)
+
 set(CMAKE_CXX_STANDARD 17)
 
 include_directories(${CMAKE_JS_INC})
@@ -19,4 +22,4 @@ execute_process(
 string(REPLACE "\n" "" NODE_ADDON_API_DIR ${NODE_ADDON_API_DIR})
 string(REPLACE "\"" "" NODE_ADDON_API_DIR ${NODE_ADDON_API_DIR})
 target_include_directories(${PROJECT_NAME} PRIVATE ${NODE_ADDON_API_DIR})
-target_link_libraries(${PROJECT_NAME} ${CMAKE_JS_LIB} fmt stdc++fs)
+target_link_libraries(${PROJECT_NAME} ${CMAKE_JS_LIB} ${STDCPPFS_LIBRARY} fmt::fmt)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-sandbox",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "description": "A simple sandbox for Node.js using Linux namespaces and cgroup.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
When using some C++ package manager (e.g. vcpkg) to manage C++ libraries instead of system package manager, `target_link_libraries(${PROJECT_NAME} fmt)` cannot find and link the library correctly. It it because CMake will only pass `-lfmt` to the compiler under this circumstance but the compiler does not know where to find libfmt.

The solution is to use `find_packge(fmt)`. Then CMake will find the exact path of libfmt and pass `-L <exact path>` to the compiler.

However, `target_link_libraries(${PROJECT_NAME} ${CMAKE_JS_LIB} stdc++fs fmt::fmt)` will cause a warning CMP0003 (https://cmake.org/cmake/help/latest/policy/CMP0003.html). The solution is to use `find_library` to get the exact path of libstdc++fs in advance.