### PR TITLE
docs: update the grub commands for distros with systemd >= v256

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,18 @@ Add `swapaccount=1` to `GRUB_CMDLINE_LINUX_DEFAULT` section in `/etc/default/gru
 GRUB_CMDLINE_LINUX_DEFAULT="quiet splash cgroup_enable=memory swapaccount=1"
 ```
 
-Some distro [enables cgroup v2 by default in their new versions](https://rootlesscontaine.rs/getting-started/common/cgroup2/), including Arch Linux (since April 2021), Fedora (since 31) and Debian. If you cannot find the directory `/sys/fs/cgroup/memory/`, this is the case for you. In this case, you also need to add the parameter `systemd.unified_cgroup_hierarchy=0` to enable cgroup v1: 
+Some distro [enables cgroup v2 by default in their new versions](https://rootlesscontaine.rs/getting-started/common/cgroup2/), including Arch Linux (since April 2021), Fedora (since 31) and Debian. If you cannot find the directory `/sys/fs/cgroup/memory/`, this is the case for you. In this case, you also need to add the parameter `systemd.unified_cgroup_hierarchy=0` to enable cgroup v1 and the parameter `SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1` to [force systemd to work with cgroup v1](https://github.com/systemd/systemd/issues/30852): 
 
 ```bash
-GRUB_CMDLINE_LINUX_DEFAULT="quiet splash cgroup_enable=memory swapaccount=1 systemd.unified_cgroup_hierarchy=0"
+GRUB_CMDLINE_LINUX_DEFAULT="quiet splash cgroup_enable=memory swapaccount=1 SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1 systemd.unified_cgroup_hierarchy=0"
 ```
+
+<details>
+  <summary>Troubleshooting if you didn't set <code>SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1</code> and cannot boot:</summary>
+  <p>Enter the GRUB menu during reboot and edit the boot command of your OS. Now you can add the parameter (temporarily) and boot successfully.</p>
+  <p>Do not forget to update <code>/etc/default/grub</code> after you boot, or you will need to manually edit the command on every boot.</p>
+</details>
+
 
 And then run
 ```bash


### PR DESCRIPTION
对于一些较新的发行版而言（systemd 版本在 v256 及以后），仅仅设置 `systemd.unified_cgroup_hierarchy=0` 会导致 systemd 拒绝运行，从而机器无法启动（[参考链接1](https://wiki.archlinux.org/title/Cgroups#Enable_cgroup_v1)、[参考链接2](https://github.com/systemd/systemd/commit/f2512de82dc91cfb742a4f4df934bdb4fcad482d)）。**这对于参考 simple-sandbox 旧版说明的用户而言可能是致命的。**

因此，我认为应该修改文档，新增必要的内核启动参数。

~~当然，更长远来看，最好是项目本身能适配 cgroup v2（画大饼，别听）~~